### PR TITLE
Add Changelog to Documentation

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -1,71 +1,81 @@
 
-Changelog
-=========
+===========
+ Changelog
+===========
+
+
+1.1.0
+=====
+
+* Moves project to GitHub
+* Integrates with Travis CI
+* Documentation updates
+* Documentation published on Read The Docs
 
 
 1.0.2
------
+=====
 
 * Fixes embarrassing bug that was causing this extension to do
   essentially nothing.
 
 
 1.0.1
------
+=====
 
 * Fixes specification of the ``flake8.extension`` entry point.
 
 
 1.0.0
------
+=====
 
 * Bumps version to 1.0.0.
 
 
 0.10.3
-------
+======
 
 * Links the issue tracker in the README.
 
 
 0.10.2
-------
+======
 
 * Fixed packaging bug related to changes in 0.10.1.
 
 
 0.10.1
-------
+======
 
 * Cleaned up packaging (include CHANGELOG and LICENSE in package, do
   not include redundant README.rst).
 
 
 0.10.0
-------
+======
 
 * Formalized and documented Python 3 and PyPy support.
 
 
 0.9.4
------
+=====
 
 * Fixed copyright on this project.
 
 
 0.9.3
------
+=====
 
 * Added this changelog.
 
 
 0.9.2
------
+=====
 
 * Initial public release.
 
 
 Pre-0.9.2
----------
+=========
 
 Initial releases and testing of the release tooling.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -4,10 +4,11 @@
 ==================
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 1
 
    usage
    syntax
+   changelog
    contributing
    internals
    roadmap


### PR DESCRIPTION
During the restructuring, the changelog got lost in the shuffle and never reappeared in a user-facing way. This commit puts the changelog into the documentation, which is published on the main project site.