### PR TITLE
Fix Errors on Regex Options

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -3,6 +3,12 @@
  Changelog
 ===========
 
+2.0.1
+=====
+
+* Fixes errors when options are undefined or ``None`` (from Sam Bull
+  of Kopernio)
+
 2.0.0
 =====
 

--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -26,9 +26,7 @@ Recommendations:
 
 * All supported Python interpreters
 
-  * Python 2.6
   * Python 2.7
-  * Python 3.3
   * Python 3.4
   * Python 3.5
   * Python 3.6

--- a/src/flake8_ownership.py
+++ b/src/flake8_ownership.py
@@ -84,7 +84,8 @@ class Checker(object):
 
     @classmethod
     def _parse_option(cls, options, option):
-        regexes = getattr(options, option, ()).split(',')
+        regexes = getattr(options, option, '') or ''
+        regexes = regexes.split(',')
         if len(regexes) == 1 and regexes[0] == '':
             return []
 

--- a/src/test.py
+++ b/src/test.py
@@ -115,6 +115,15 @@ class OptionTest(unittest.TestCase):
         self.assertEqual(1, len(Checker.copyright_re))
         self.assertEqual(2, len(Checker.license_re))
 
+    def test_parse_options_none(self):
+        """Test when option is not defined or has a default value of None."""
+        options = mock.Mock(spec=())
+        options.author_re = None
+        Checker.parse_options(options)
+        self.assertEqual(0, len(Checker.author_re))
+        self.assertEqual(0, len(Checker.copyright_re))
+        self.assertEqual(0, len(Checker.license_re))
+
 
 class CheckerTest(unittest.TestCase):
     """Test the actual checks."""


### PR DESCRIPTION
See PR #12 for the origin of this fix. This was put into a separate PR because the changes had to be rebased onto an updated master (which fixed another, unrelated issue).